### PR TITLE
Remove EF Core package references

### DIFF
--- a/src/Providers/FluentCMS.Infrastructure.Providers/FluentCMS.Infrastructure.Providers.csproj
+++ b/src/Providers/FluentCMS.Infrastructure.Providers/FluentCMS.Infrastructure.Providers.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Removed Microsoft.EntityFrameworkCore and Microsoft.EntityFrameworkCore.Sqlite (v10.0.2) PackageReference entries from FluentCMS.Infrastructure.Providers.csproj. This trims EF Core dependencies from the Providers project — if EF is still needed, add the references to the appropriate project or restore them here.